### PR TITLE
Fixed a bug that caused mocked managers with ManyToMany relationships to...

### DIFF
--- a/mock_django/managers.py
+++ b/mock_django/managers.py
@@ -47,4 +47,6 @@ def ManagerMock(manager, *return_value):
     m.exists = m.get_query_set().exists
     m.__iter__ = m.get_query_set().__iter__
     m.__getitem__ = m.get_query_set().__getitem__
+    m.__class__ = m
+    
     return m


### PR DESCRIPTION
... fail creating the RelatedManyManager

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dcramer/mock-django/26)

<!-- Reviewable:end -->
