### PR TITLE
Excludes tests from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author='David Cramer',
     author_email='dcramer@gmail.com',
     url='http://github.com/dcramer/mock-django',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests', 'tests.*']),
     install_requires=[
         'Django>=1.4',
         'mock',


### PR DESCRIPTION
Hi and thanks for mock-django

I ran into an issue when testing one of my reusable django apps: my tests are usually in a tests package so that importing `tests` imports this test package. When I use mock-django, it imports mock-django's test package instead.

It would be more adequate not to include mock-django's tests in the distribution. Hence this PR.

This does not change anything for the tox suite (at least for me) as it imports the tests from the root `tests` module.