### PR TITLE
Hides MergeDict except when needed

### DIFF
--- a/mock_django/http.py
+++ b/mock_django/http.py
@@ -8,7 +8,6 @@ mock_django.http
 
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
-from django.utils.datastructures import MergeDict
 try:
     # Python 2
     from urllib import urlencode
@@ -29,6 +28,7 @@ class WsgiHttpRequest(HttpRequest):
         self.POST = {}
 
     def _get_request(self):
+        from django.utils.datastructures import MergeDict
         if not hasattr(self, '_request'):
             self._request = MergeDict(self.POST, self.GET)
         return self._request

--- a/tests/mock_django/http/tests.py
+++ b/tests/mock_django/http/tests.py
@@ -1,9 +1,9 @@
 try:
     # Python 2
-    from unittest2 import TestCase
+    from unittest2 import TestCase, skipIf
 except ImportError:
     # Python 3
-    from unittest import TestCase
+    from unittest import TestCase, skipIf
 
 try:
     # Python 2
@@ -12,8 +12,8 @@ except ImportError:
     # Python 3
     from urllib.parse import urlencode
 
+import django
 from django.contrib.auth.models import AnonymousUser
-from django.utils.datastructures import MergeDict
 
 from mock import Mock
 
@@ -31,7 +31,9 @@ class WsgiHttpRequestTest(TestCase):
         self.assertEqual({}, wsgi_r.GET)
         self.assertEqual({}, wsgi_r.POST)
 
+    @skipIf(django.VERSION >= (1, 9), "MergeDict and REQUEST removed in Django 1.9")
     def test__get_request(self):
+        from django.utils.datastructures import MergeDict
         wsgi_r = WsgiHttpRequest()
         expected_items = MergeDict({}, {}).items()
 


### PR DESCRIPTION
MegeDict has been removed in Django 1.9 along with the `REQUEST` attribute on the HttpRequest class in [ticket 18659](https://code.djangoproject.com/ticket/18659).

The import is moved into functions that should only be called when testing against Django 1.8 or lower, and the one test that references this functionality should be skipped for newer versions.

This patch doesn't make any other changes to test the package against Django 1.9, however I can confirm that locally the test suite passed for mock-django using tox, and with my patch I was able to continue using mock-django to test [django-organizations](https://github.com/bennylope/django-organizations/tree/django-19) against Django 1.9.