### PR TITLE
Collapse tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,82 +4,25 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py34-1.8,py34-1.7,py34-1.6,py34-1.5,py27-1.8,py27-1.7,py27-1.6,py26-1.6,py27-1.5,py26-1.5,py27-1.4,py26-1.4
+envlist =
+    py34-django{1.8,1.7,1.6,1.5},
+    py27-django{1.8,1.7,1.6,1.5,1.4},
+    py26-django{1.6,1.5,1.4}
 
 [testenv]
 commands = {envpython} runtests.py
+basepython =
+    py26: python2.6
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+    pypy: pypy
+    pypy3: pypy3
 deps =
-    nose
-    unittest2
-
-[testenv:py34-1.8]
-basepython = python3.4
-deps =
+    django1.4: Django==1.4
+    django1.5: Django==1.5
+    django1.6: Django==1.6
+    django1.7: Django==1.7
+    django1.8: Django==1.8
+    django1.9: Django==1.9a1
     -r{toxinidir}/tests/requirements.txt
-    django==1.8
-
-[testenv:py27-1.8]
-basepython = python2.7
-deps =
-    -r{toxinidir}/tests/requirements.txt
-    django==1.8
-
-[testenv:py34-1.7]
-basepython = python3.4
-deps =
-    -r{toxinidir}/tests/requirements.txt
-    django==1.7
-
-[testenv:py27-1.7]
-basepython = python2.7
-deps =
-    -r{toxinidir}/tests/requirements.txt
-    django==1.7
-
-[testenv:py34-1.6]
-basepython = python3.4
-deps =
-    -r{toxinidir}/tests/requirements.txt
-    django==1.6
-
-[testenv:py27-1.6]
-basepython = python2.7
-deps =
-    -r{toxinidir}/tests/requirements.txt
-    django==1.6
-
-[testenv:py26-1.6]
-basepython = python2.6
-deps =
-    -r{toxinidir}/tests/requirements.txt
-    django==1.6
-
-[testenv:py34-1.5]
-basepython = python3.4
-deps =
-    -r{toxinidir}/tests/requirements.txt
-    django==1.5
-
-[testenv:py27-1.5]
-basepython = python2.7
-deps =
-    -r{toxinidir}/tests/requirements.txt
-    django==1.5
-
-[testenv:py26-1.5]
-basepython = python2.6
-deps =
-    -r{toxinidir}/tests/requirements.txt
-    django==1.5
-
-[testenv:py27-1.4]
-basepython = python2.7
-deps =
-    -r{toxinidir}/tests/requirements.txt
-    django==1.4
-
-[testenv:py26-1.4]
-basepython = python2.6
-deps =
-    -r{toxinidir}/tests/requirements.txt
-    django==1.4


### PR DESCRIPTION
Simplifies the file and makes it easier to add/remove environments.

I started some work to test against Django 1.9 and it was far easier to start with a simplified tox file.

This doesn't change the environments tested against in any way, it's only a refactoring of the tox configuration.

If this is good to go then Django 1.9 testing will follow right behind.