### PR TITLE
Add Django 1.9 testing support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,50 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "pypy"
-  - "pypy3"
+python: 2.7
 env:
-  - DJANGO=1.4.13
-  - DJANGO=1.5.8
-  - DJANGO=1.6.5
-  - DJANGO=1.7.0
-  - DJANGO=1.8.0
+
+  - TOX_ENV=flake8
+
+  - TOX_ENV=py34-django1.9
+  - TOX_ENV=py34-django1.8
+  - TOX_ENV=py34-django1.7
+  - TOX_ENV=py34-django1.6
+  - TOX_ENV=py34-django1.5
+
+  - TOX_ENV=py33-django1.8
+  - TOX_ENV=py33-django1.7
+  - TOX_ENV=py33-django1.6
+  - TOX_ENV=py33-django1.5
+
+  - TOX_ENV=py32-django1.8
+  - TOX_ENV=py32-django1.7
+  - TOX_ENV=py32-django1.6
+  - TOX_ENV=py32-django1.5
+
+  - TOX_ENV=py27-django1.9
+  - TOX_ENV=py27-django1.8
+  - TOX_ENV=py27-django1.7
+  - TOX_ENV=py27-django1.6
+  - TOX_ENV=py27-django1.5
+  - TOX_ENV=py27-django1.4
+
+  - TOX_ENV=py26-django1.6
+  - TOX_ENV=py26-django1.5
+  - TOX_ENV=py26-django1.4
+
+  - TOX_ENV=pypy-django1.9
+  - TOX_ENV=pypy-django1.8
+  - TOX_ENV=pypy-django1.7
+  - TOX_ENV=pypy-django1.6
+  - TOX_ENV=pypy-django1.5
+  - TOX_ENV=pypy-django1.4
+
+  - TOX_ENV=pypy3-django1.8
+  - TOX_ENV=pypy3-django1.7
+  - TOX_ENV=pypy3-django1.6
+  - TOX_ENV=pypy3-django1.5
+
 install:
-  - sudo apt-get install libevent-dev
-  - sudo pip install Django==$DJANGO --use-mirrors
-  - sudo pip install pep8 --use-mirrors
-  - sudo pip install https://github.com/dcramer/pyflakes/tarball/master
-  - sudo pip install -e . --use-mirrors
+  - pip install tox
 script:
-  - "sudo pep8 --ignore=E501,E225 mock_django"
-  - sudo pyflakes -x W mock_django
-  - sudo python setup.py test
+  - tox -e $TOX_ENV
+sudo: false

--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+
+import django
 from django.conf import settings
 # collector import is required otherwise setuptools errors
 from nose.core import run, collector
@@ -8,7 +10,18 @@ from nose.core import run, collector
 # anything that tries to access attributes of `django.conf.settings` will just
 # return the default values, instead of crashing out.
 if not settings.configured:
-    settings.configure()
+    settings.configure(
+        INSTALLED_APPS=[
+            "django.contrib.contenttypes",
+            "django.contrib.auth",
+        ],
+    )
+
+try:
+    django.setup()
+except AttributeError:
+    # Django 1.7 or lower
+    pass
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -5,17 +5,20 @@
 
 [tox]
 envlist =
-    py34-django{1.8,1.7,1.6,1.5},
-    py27-django{1.8,1.7,1.6,1.5,1.4},
-    py26-django{1.6,1.5,1.4}
+    py34-django{1.9,1.8,1.7,1.6,1.5},
+    py27-django{1.9,1.8,1.7,1.6,1.5,1.4},
+    py26-django{1.6,1.5,1.4},
+    flake8
 
 [testenv]
 commands = {envpython} runtests.py
 basepython =
-    py26: python2.6
-    py27: python2.7
-    py34: python3.4
     py35: python3.5
+    py34: python3.4
+    py33: python3.4
+    py32: python3.4
+    py27: python2.7
+    py26: python2.6
     pypy: pypy
     pypy3: pypy3
 deps =
@@ -26,3 +29,12 @@ deps =
     django1.8: Django==1.8
     django1.9: Django==1.9a1
     -r{toxinidir}/tests/requirements.txt
+
+[testenv:flake8]
+basepython=python
+deps=flake8
+commands=
+    flake8 mock_django
+
+[flake8]
+ignore = E501,E225,F403


### PR DESCRIPTION
1. Add Django 1.9 (1.9a1) test environment
2. Add Python 3.2 and Python 3.3 interpreters to basepython
3. Add flake8 environment
4. Use tox for Travis
5. Remove unsupported Python/Django combinations

-----------

1. Django 1.9: pulls from alpha version on PyPI. Should be pretty easy to update the version here, and shouldn't be any feature changes between alpha and .0 version. Configures settings with installed apps and setup Django. This is required for tests against Django 1.9, which otherwise results in AppRegistryNotReady exceptions (if not setup) or RuntimeError exceptions if either `django.contrib.contenttypes` or `django.contrib.auth` is not installed.

2. Interpreter definitions here allow optional environment testing and using tox to control environment creation from other sources (e.g. CI).

3. Adds flake8 as a combintion of pyflakes and pep8 checking applied in the Travis config only. Helpful to have in the tests contributors are expected to run. Includes existing ignored rules from Travis config and adds ignore rule for undetected imported names from * import for consistency with existing code.

4. Specifying test environments with tox is *slightly* more verbose but has two major benefits: consistency of test versions since these are all defined by tox and simplified matrix management (see below). As a bonus, tox can handle any environment setup. The new Travis file ensures that the builds are run on the newer container infrastructure too.

5. Removed incompatible Python/Django combinations: running tox environments, some combinations fail, e.g. Python 3.2 and Django 1.8 because the latter doesn't support the former. This is in the form of changed API references from Django to Python, not a matter of unapplied tests. There should be no reason to test against combinations that won't work in the wild. Some of these tests may have passed before the inclusion of `django.setup()` added for Django 1.9 testing.